### PR TITLE
Only add yum requirement on YUM-based platforms

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,12 @@ version          '0.1.0'
   supports os
 end
 
-%w{ yum apt python logrotate }.each do |ckbk|
+case node["platform"
+when "fedora", "centos", "redhat"
+  depends yum
+end
+
+
+%w{  apt python logrotate }.each do |ckbk|
   depends ckbk
 end


### PR DESCRIPTION
Yum is not needed on Ubuntu systems, and sometimes this causes constraint problems.
