### PR TITLE
Permission issue on agent.conf (and server.conf)

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -11,7 +11,7 @@ template "/etc/logstash/conf.d/agent.conf" do
   source "logstash.conf.erb"
   owner "logstash"
   group "logstash"
-  mode "0755"
+  mode "0644"
   variables( :config => node[:logstash][:agent] )
   notifies :restart, "service[logstash]"
 end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -8,6 +8,9 @@
 #
 
 template "/etc/logstash/conf.d/agent.conf" do
+  owner "logstash"
+  group "logstash"
+  mode "0755"
   source "logstash.conf.erb"
   variables( :config => node[:logstash][:agent] )
   notifies :restart, "service[logstash]"

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -8,10 +8,10 @@
 #
 
 template "/etc/logstash/conf.d/agent.conf" do
+  source "logstash.conf.erb"
   owner "logstash"
   group "logstash"
   mode "0755"
-  source "logstash.conf.erb"
   variables( :config => node[:logstash][:agent] )
   notifies :restart, "service[logstash]"
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -9,6 +9,9 @@
 
 template "/etc/logstash/conf.d/server.conf" do
   source "logstash.conf.erb"
+  owner "logstash"
+  group "logstash"
+  mode "0755"
   variables( :config => node[:logstash][:server] )
   notifies :restart, "service[logstash]"
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -11,7 +11,7 @@ template "/etc/logstash/conf.d/server.conf" do
   source "logstash.conf.erb"
   owner "logstash"
   group "logstash"
-  mode "0755"
+  mode "0644"
   variables( :config => node[:logstash][:server] )
   notifies :restart, "service[logstash]"
 end


### PR DESCRIPTION
I encountered the following error 

```

{:timestamp=>"2014-06-30T21:53:48.215000+0000", :message=>"+---------------------------------------------------------+\n| An unexpected error occurred. This is probably a bug.   |\n| You can find help with this problem in a few places:    |\n|                                                         |\n| * chat: #logstash IRC channel on freenode irc.          |\n|     IRC via the web: http://goo.gl/TI4Ro                |\n| * email: logstash-users@googlegroups.com                |\n| * bug system: https://logstash.jira.com/                |\n|                                                         |\n+---------------------------------------------------------+\nThe error reported is: \n  Permission denied - /etc/logstash/conf.d/agent.conf"}
```

This was fixed by adding the same permission settings on the configuration files as on the configuration folders.