### PR TITLE
fixed service provider for non ubuntu platforms

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,9 +49,14 @@ execute "remove-agent-conf" do
 end
 
 service "logstash" do
+  case node["platform"]
+    when "ubuntu"
+      if node["platform_version"].to_f >= 14.04
+        provider Chef::Provider::Service::Upstart
+      end
+  end
   supports :restart => true, :reload => false
   action :nothing
-  provider Chef::Provider::Service::Upstart
 end
 
 include_recipe "logstash::server" if node[:logstash][:server][:enabled]


### PR DESCRIPTION
Ubuntu 14.04 shipped with two different init systems. Upstart deals
with this scenario nicely. For Ubuntu versions less than 14.04 and for
other platforms, letting Ohai and chef-client/chef-solo figure out the
platform works great, so there is no need to set the provider
explicitly.