### PR TITLE
Update server.rb

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -9,6 +9,9 @@
 
 template "/etc/logstash/conf.d/server.conf" do
   source "logstash.conf.erb"
+  owner "logstash"
+  group "logstash"
+  mode "0644"
   variables( :config => node[:logstash][:server] )
   notifies :restart, "service[logstash]"
 end


### PR DESCRIPTION
Permissions cause a file not found error: 
FATAL: Chef::Exceptions::ResourceNotFound: resource template[/etc/logstash/conf.d/server.conf] is configured to notify resource service[logstash] with action restart, but service[logstash] cannot be found in the resource collection. template[/etc/logstash/conf.d/server.conf] is defined in /opt/aws/opsworks/releases/20150219093733_23900020150219093733/site-cookbooks/logstash/recipes/server.rb:10:in `from_file'