### PR TITLE
Move package installation up front

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,12 +3,14 @@
 # Recipe:: default
 #
 # Copyright (C) 2014 Wouter de Vos
-# 
+#
 # License: MIT
 #
 
 include_recipe "logstash::yumrepo" if platform_family? "rhel", "fedora"
 include_recipe "logstash::apt"     if platform_family? "debian"
+
+package "logstash"
 
 directory "/etc/logstash" do
   owner "logstash"
@@ -27,8 +29,6 @@ directory "/var/lib/monit" do
   group "logstash"
   mode "0755"
 end
-
-package "logstash"
 
 execute "remove-server-conf" do
   command %{


### PR DESCRIPTION
This is so the logstash user and group are already created prior to `chown`-ing the directory.